### PR TITLE
Loadster don't use JMeter, Perforce BlazeMeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This list grew up from [an occasional answer](https://sqa.stackexchange.com/a/25
 
 *List of cloud-based load testing services with support of JMeter test plans execution.*
 
-- [CA BlazeMeter](https://www.blazemeter.com/) - Performance engineering platform with JMeter and Selenium support.
+- [Perforce BlazeMeter](https://www.blazemeter.com/) - Performance engineering platform with JMeter and Selenium support.
 - [OctoPerf](https://octoperf.com/) - SaaS and On-Premise Load Testing Tool with JMeter and Selenium support.
 - [Tricentis Flood](https://www.flood.io/) - Load testing service with JMeter, Gatling and Selenium scenarios support.
 - [RedLine13](https://redline13.com/) - AWS-based load testing service with JMeter, Gatling and Selenium scenarios support.


### PR DESCRIPTION
Remove Loadster because this solution don't use JMeter or JMeter script
Perforce BlazeMeter no more CA BlazeMeter