### PR TITLE
Add Latency Lingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ This list grew up from [an occasional answer](https://sqa.stackexchange.com/a/25
 ## Results Processing
 
 - [JMeter Report Dashboard](https://jmeter.apache.org/usermanual/generating-dashboard.html) - JMeter supports dashboard report generation to get graphs and statistics from a test plan.
+- [Latency Lingo](https://latencylingo.com) - Publish test results to generate hosted, interactive dashboards containing insights.
 
 ### Results Analysis
 


### PR DESCRIPTION
Hello! I recently created [Latency Lingo](https://latencylingo.com) to help JMeter users manage the results of tests executed anywhere. Publish your results with a single command from our [CLI](https://github.com/AnthonyBobsin/latency-lingo-cli) and you'll have access to all your test results in a web-based application.

I'd like to add this to your repository as a resource. [Here's the documentation](https://docs.latencylingo.com/docs/intro) to provide a bit more context.

Thanks! 