### PR TITLE
Remove - JMeter Google Group link

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ This list grew up from [an occasional answer](https://sqa.stackexchange.com/a/25
 ### Forums
 
 <!--lint ignore double-link-->
-- [JMeter Google Group](https://groups.google.com/forum/#!forum/ptgram24)
 - [JMeterPlugins Google Group](https://groups.google.com/forum/#!forum/jmeter-plugins)
 
 ### Twitter


### PR DESCRIPTION
The JMeter Google Group  is corrupted by tens of thousands of spam and fake accounts created by bots. JMeter Google Group is no longer a recommended Google Group.